### PR TITLE
build: Create a oem image when BOARD_OEMIMAGE_FILE_SYSTEM_TYPE is def…

### DIFF
--- a/core/Makefile
+++ b/core/Makefile
@@ -1650,6 +1650,7 @@ endif
 
 # Depending on the various images guarantees that the underlying
 # directories are up-to-date.
+include $(BUILD_SYSTEM)/tasks/oem_image.mk
 $(BUILT_TARGET_FILES_PACKAGE): \
 		$(INSTALLED_BOOTIMAGE_TARGET) \
 		$(INSTALLED_RADIOIMAGE_TARGET) \
@@ -1658,6 +1659,7 @@ $(BUILT_TARGET_FILES_PACKAGE): \
 		$(INSTALLED_USERDATAIMAGE_TARGET) \
 		$(INSTALLED_CACHEIMAGE_TARGET) \
 		$(INSTALLED_VENDORIMAGE_TARGET) \
+		$(INSTALLED_OEMIMAGE_TARGET) \
 		$(INSTALLED_ANDROID_INFO_TXT_TARGET) \
 		$(SELINUX_FC) \
 		$(built_ota_tools) \
@@ -1766,6 +1768,11 @@ ifdef BOARD_VENDORIMAGE_FILE_SYSTEM_TYPE
 	@# Contents of the vendor image
 	$(hide) $(call package_files-copy-root, \
 		$(TARGET_OUT_VENDOR),$(zip_root)/VENDOR)
+endif
+ifdef BOARD_OEMIMAGE_FILE_SYSTEM_TYPE
+	@# Contents of the oem image
+	$(call package_files-copy-root, \
+		$(TARGET_OUT_OEM),$(zip_root)/OEM)
 endif
 	@# Extra contents of the OTA package
 	$(hide) mkdir -p $(zip_root)/OTA/bin

--- a/core/tasks/oem_image.mk
+++ b/core/tasks/oem_image.mk
@@ -15,7 +15,16 @@
 #
 
 # We build oem.img only if it's asked for.
+skip_oem_image := true
 ifneq ($(filter $(MAKECMDGOALS),oem_image),)
+    skip_oem_image := false
+endif
+
+ifneq ($(BOARD_OEMIMAGE_FILE_SYSTEM_TYPE),)
+    skip_oem_image := false
+endif
+
+ifneq ($(skip_oem_image),true)
 ifndef BOARD_OEMIMAGE_PARTITION_SIZE
 $(error BOARD_OEMIMAGE_PARTITION_SIZE is not set.)
 endif
@@ -43,4 +52,4 @@ $(INSTALLED_OEMIMAGE_TARGET) : $(INTERNAL_USERIMAGES_DEPS) $(INTERNAL_OEMIMAGE_F
 oem_image : $(INSTALLED_OEMIMAGE_TARGET)
 $(call dist-for-goals, oem_image, $(INSTALLED_OEMIMAGE_TARGET))
 
-endif  # oem_image in $(MAKECMDGOALS)
+endif

--- a/tools/releasetools/add_img_to_target_files.py
+++ b/tools/releasetools/add_img_to_target_files.py
@@ -100,6 +100,29 @@ def BuildVendor(input_dir, info_dict, block_list=None):
   file containing it."""
   return CreateImage(input_dir, info_dict, "vendor", block_list=block_list)
 
+def AddOem(output_zip, prefix="IMAGES/"):
+  """Turn the contents of OEM into a oem image and store in it
+  output_zip."""
+
+  prebuilt_path = os.path.join(OPTIONS.input_tmp, prefix, "oem.img")
+  if os.path.exists(prebuilt_path):
+    print("oem.img already exists in %s, no need to rebuild..." % prefix)
+    return
+
+  block_list = common.MakeTempFile(prefix="oem-blocklist-", suffix=".map")
+  imgname = BuildOem(OPTIONS.input_tmp, OPTIONS.info_dict,
+                     block_list=block_list)
+  with open(imgname, "rb") as f:
+    common.ZipWriteStr(output_zip, prefix + "oem.img", f.read())
+  with open(block_list, "rb") as f:
+    common.ZipWriteStr(output_zip, prefix + "oem.map", f.read())
+
+
+def BuildOem(input_dir, info_dict, block_list=None):
+  """Build the (sparse) oem image and return the name of a temp
+  file containing it."""
+  return CreateImage(input_dir, info_dict, "oem", block_list=block_list)
+
 
 def CreateImage(input_dir, info_dict, what, block_list=None):
   print("creating " + what + ".img...")
@@ -314,6 +337,12 @@ def AddImagesToTargetFiles(filename):
   except KeyError:
     has_vendor = False
 
+  try:
+    input_zip.getinfo("OEM/")
+    has_oem = True
+  except KeyError:
+    has_oem = False
+
   OPTIONS.info_dict = common.LoadInfoDict(input_zip)
   if "selinux_fc" in OPTIONS.info_dict:
     OPTIONS.info_dict["selinux_fc"] = os.path.join(
@@ -365,6 +394,10 @@ def AddImagesToTargetFiles(filename):
   AddUserdataExtra(output_zip)
   banner("cache")
   AddCache(output_zip)
+  if has_oem:
+    banner("oem")
+    AddOem(output_zip)
+
 
   common.ZipClose(output_zip)
 

--- a/tools/releasetools/img_from_target_files.py
+++ b/tools/releasetools/img_from_target_files.py
@@ -165,6 +165,12 @@ def main(argv):
         add_img_to_target_files.AddUserdataExtra(output_zip, prefix="")
         banner("AddCache")
         add_img_to_target_files.AddCache(output_zip, prefix="")
+        try:
+          input_zip.getinfo("OEM/")
+          banner("AddOem")
+          add_img_to_target_files.AddOem(output_zip, prefix="")
+        except KeyError:
+          pass   # no oem partition for this device
 
   finally:
     print("cleaning up...")


### PR DESCRIPTION
…ined

This adds the capability of generating a OEM image with the build
and adding it to target files when BOARD_OEMIMAGE_FILE_SYSTEM_TYPE
is set.

Change-Id: I6c596d58d9d5ece1a261d953eeb8c60eac30e642
Ticket: CYNGNOS-936
(cherry picked from commit 1966a9e7c22b95eb4c16be6aee7adf43cb6ce118)
